### PR TITLE
nginx: Don't use absolute URL in /email redirects

### DIFF
--- a/crAPI/services/web/nginx.conf.template
+++ b/crAPI/services/web/nginx.conf.template
@@ -65,6 +65,7 @@ server {
     proxy_pass http://${MAILHOG_UI}/;
     proxy_set_header Host ${MAILHOG_UI};
     proxy_set_header X-Forwarded-Host $http_host;
+    absolute_redirect off;
   }
 
   location /images {


### PR DESCRIPTION
Signed-off-by: Akshath Kothari <akshath.kothari@levo.ai>