### PR TITLE
fix: Reduce the time we wait for MongoDB to be up before proceeding

### DIFF
--- a/.github/workflows/publish-crapi-all-image.yml
+++ b/.github/workflows/publish-crapi-all-image.yml
@@ -56,7 +56,7 @@ jobs:
 
   push-crapi-all-to-dockerhub:
     name: Publish
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-crapi-all-image.yml
+++ b/.github/workflows/publish-crapi-all-image.yml
@@ -100,5 +100,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           image: levoai/crapi-all
+          tag: latest
           path: ./crAPI
           cache: false

--- a/.github/workflows/publish-crapi-all-image.yml
+++ b/.github/workflows/publish-crapi-all-image.yml
@@ -56,7 +56,7 @@ jobs:
 
   push-crapi-all-to-dockerhub:
     name: Publish
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/MalSchema/database/schema.sql
+++ b/MalSchema/database/schema.sql
@@ -3,3 +3,5 @@ CREATE TABLE booking (
     name VARCHAR(30),
     is_active BOOLEAN
 );
+
+INSERT INTO booking (id, name, is_active) values (1, 'Booking 1', true);

--- a/crAPI/start_all_services.sh
+++ b/crAPI/start_all_services.sh
@@ -26,14 +26,16 @@ waitport 5432
 print_banner "Starting MongoDB"
 /usr/bin/mongod -f /etc/mongod.conf --auth --fork --quiet --logpath /var/log/mongodb.log --logappend
 
-# Wait until mongo logs that it's ready (or timeout after 60s)
+# Wait until mongo logs that it's ready (or timeout after 10s)
 COUNTER=0
 grep -q 'waiting for connections on port' /var/log/mongodb.log
-while [[ $? -ne 0 && $COUNTER -lt 60 ]] ; do
-    sleep 2
-    let COUNTER+=2
+while [[ $? -ne 0 && $COUNTER -lt 10 ]] ; do
+    sleep 1
+    let COUNTER+=1
     echo "Waiting for mongo to initialize... ($COUNTER seconds so far)"
     grep -q 'waiting for connections on port' /var/log/mongodb.log
+    ls /var/log/mongodb.log
+    cat /var/log/mongodb.log
 done
 
 # Initialize the MongoDB with init users.

--- a/crAPI/start_all_services.sh
+++ b/crAPI/start_all_services.sh
@@ -34,8 +34,6 @@ while [[ $? -ne 0 && $COUNTER -lt 10 ]] ; do
     let COUNTER+=1
     echo "Waiting for mongo to initialize... ($COUNTER seconds so far)"
     grep -q 'waiting for connections on port' /var/log/mongodb.log
-    ls /var/log/mongodb.log
-    cat /var/log/mongodb.log
 done
 
 # Initialize the MongoDB with init users.


### PR DESCRIPTION
This change is done mainly to reduce the total startup time of crapi-all fat container.