### PR TITLE
Add nodeselectors to the crapi pods

### DIFF
--- a/crAPI/deploy/k8s/base/community/deployment.yaml
+++ b/crAPI/deploy/k8s/base/community/deployment.yaml
@@ -12,21 +12,23 @@ spec:
       labels:
         app: crapi-community
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       initContainers:
         - name: wait-for-postgres
-          image: groundnuty/k8s-wait-for:v1.3
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "service"
             - "postgresdb"
         - name: wait-for-mongo
-          image: groundnuty/k8s-wait-for:v1.3
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "service"
             - "mongodb"
         - name: wait-for-java
-          image: groundnuty/k8s-wait-for:v1.3
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "service"

--- a/crAPI/deploy/k8s/base/identity/deployment.yaml
+++ b/crAPI/deploy/k8s/base/identity/deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: crapi-identity
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       initContainers:
         - name: wait-for-postgres
-          image: groundnuty/k8s-wait-for:v1.3
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "service"

--- a/crAPI/deploy/k8s/base/mailhog/deployment.yaml
+++ b/crAPI/deploy/k8s/base/mailhog/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       annotations:
         sidecar.traceable.ai/inject: "false"
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       securityContext:
         runAsUser: 0
         runAsGroup: 0

--- a/crAPI/deploy/k8s/base/web/deployment.yaml
+++ b/crAPI/deploy/k8s/base/web/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: crapi-web
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
       - name: crapi-web
         image: levoai/crapi-web:latest

--- a/crAPI/deploy/k8s/base/workshop/deployment.yaml
+++ b/crAPI/deploy/k8s/base/workshop/deployment.yaml
@@ -12,15 +12,17 @@ spec:
       labels:
         app: crapi-workshop
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       initContainers:
         - name: wait-for-crapi-identity
-          image: groundnuty/k8s-wait-for:v1.3
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "service"
             - "crapi-identity"
         - name: wait-for-crapi-community
-          image: groundnuty/k8s-wait-for:v1.3
+          image: groundnuty/k8s-wait-for:v2.0
           imagePullPolicy: Always
           args:
             - "service"


### PR DESCRIPTION
Node selectors have been added to all the crapi pods to only deploy them in amd64 machines.

I've also updated the image for the initContainers to add future support for arm machines.