### PR TITLE
Update Docker Build and Push action for ARM

### DIFF
--- a/.github/workflows/build-and-release-crapi-community.yml
+++ b/.github/workflows/build-and-release-crapi-community.yml
@@ -32,6 +32,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build image
+        if: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/community
@@ -40,7 +41,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: levoai/crapi-community:pr-build
       - name: Build and push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/community

--- a/.github/workflows/build-and-release-crapi-community.yml
+++ b/.github/workflows/build-and-release-crapi-community.yml
@@ -16,54 +16,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-community-image:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
+  build-and-push-image:
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build image
-        uses: aevea/action-kaniko@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-community
-          path: ./crAPI/services/community
-          tag: latest
-          cache: true
-          # Don't push the image, just build it to validate it.
-          extra_args: "--no-push --cache-repo levoai/crapi-community-cache"
-
-  push-latest-community-image:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Latest image push
-        uses: aevea/action-kaniko@master
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-community
-          path: ./crAPI/services/community
-          tag: latest
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-community-cache"
-
-  release-community-image:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Tagged image push
-        uses: aevea/action-kaniko@master
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-community
-          path: ./crAPI/services/community
-          strip_tag_prefix: v
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-community-cache"
+          context: ./crAPI/services/community
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: levoai/crapi-community:latest
+          cache-from: type=registry,ref=levoai/crapi-community-cache
+          cache-to: type=registry,ref=levoai/crapi-community-cache,mode=max

--- a/.github/workflows/build-and-release-crapi-community.yml
+++ b/.github/workflows/build-and-release-crapi-community.yml
@@ -38,5 +38,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: levoai/crapi-community:latest
-          cache-from: type=registry,ref=levoai/crapi-community-cache
-          cache-to: type=registry,ref=levoai/crapi-community-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-release-crapi-community.yml
+++ b/.github/workflows/build-and-release-crapi-community.yml
@@ -31,7 +31,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./crAPI/services/community
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: levoai/crapi-community:pr-build
       - name: Build and push
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/community

--- a/.github/workflows/build-and-release-crapi-identity.yml
+++ b/.github/workflows/build-and-release-crapi-identity.yml
@@ -32,6 +32,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build image
+        if: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/identity
@@ -40,7 +41,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: levoai/crapi-identity:pr-build
       - name: Build and push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/identity

--- a/.github/workflows/build-and-release-crapi-identity.yml
+++ b/.github/workflows/build-and-release-crapi-identity.yml
@@ -38,5 +38,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: levoai/crapi-identity:latest
-          cache-from: type=registry,ref=levoai/crapi-identity-cache
-          cache-to: type=registry,ref=levoai/crapi-identity-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-release-crapi-identity.yml
+++ b/.github/workflows/build-and-release-crapi-identity.yml
@@ -31,7 +31,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./crAPI/services/identity
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: levoai/crapi-identity:pr-build
       - name: Build and push
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/identity

--- a/.github/workflows/build-and-release-crapi-identity.yml
+++ b/.github/workflows/build-and-release-crapi-identity.yml
@@ -16,54 +16,27 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-identity-image:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
+  build-and-push-image:
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build image
-        uses: aevea/action-kaniko@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-identity
-          path: ./crAPI/services/identity
-          tag: latest
-          cache: true
-          # Don't push the image, just build it to validate it.
-          extra_args: "--no-push --cache-repo levoai/crapi-identity-cache"
-
-  push-latest-identity-image:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Latest image push
-        uses: aevea/action-kaniko@master
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-identity
-          path: ./crAPI/services/identity
-          tag: latest
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-identity-cache"
-
-  release-identity-image:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Tagged image push
-        uses: aevea/action-kaniko@master
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-identity
-          path: ./crAPI/services/identity
-          strip_tag_prefix: v
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-identity-cache"
+          context: ./crAPI/services/identity
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: levoai/crapi-identity:latest
+          cache-from: type=registry,ref=levoai/crapi-identity-cache
+          cache-to: type=registry,ref=levoai/crapi-identity-cache,mode=max

--- a/.github/workflows/build-and-release-crapi-web.yml
+++ b/.github/workflows/build-and-release-crapi-web.yml
@@ -32,6 +32,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build image
+        if: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/web
@@ -40,7 +41,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: levoai/crapi-web:pr-build      
       - name: Build and push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/web

--- a/.github/workflows/build-and-release-crapi-web.yml
+++ b/.github/workflows/build-and-release-crapi-web.yml
@@ -31,7 +31,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./crAPI/services/web
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: levoai/crapi-web:pr-build      
       - name: Build and push
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/web

--- a/.github/workflows/build-and-release-crapi-web.yml
+++ b/.github/workflows/build-and-release-crapi-web.yml
@@ -38,6 +38,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: levoai/crapi-web:latest
-          cache-from: type=registry,ref=levoai/crapi-web-cache
-          cache-to: type=registry,ref=levoai/crapi-web-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   

--- a/.github/workflows/build-and-release-crapi-web.yml
+++ b/.github/workflows/build-and-release-crapi-web.yml
@@ -16,57 +16,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-web-image:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
+  build-and-push-image:
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build image
-        uses: aevea/action-kaniko@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-web
-          path: ./crAPI/services/web
-          tag: latest
-          cache: true
-          # Don't push the image, just build it to validate it.
-          extra_args: "--no-push --cache-repo levoai/crapi-web-cache"
-
-  push-latest-web-image:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Latest image push
-        uses: aevea/action-kaniko@master
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-web
-          path: ./crAPI/services/web
-          tag: latest
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-web-cache"
-
-  release-web-image:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.17.1'
-
-      - name: Tagged image push
-        uses: aevea/action-kaniko@master
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-web
-          path: ./crAPI/services/web
-          strip_tag_prefix: v
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-web-cache"
+          context: ./crAPI/services/web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: levoai/crapi-web:latest
+          cache-from: type=registry,ref=levoai/crapi-web-cache
+          cache-to: type=registry,ref=levoai/crapi-web-cache,mode=max
+  

--- a/.github/workflows/build-and-release-crapi-workshop.yml
+++ b/.github/workflows/build-and-release-crapi-workshop.yml
@@ -38,6 +38,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: levoai/crapi-workshop:latest
-          cache-from: type=registry,ref=levoai/crapi-workshop-cache
-          cache-to: type=registry,ref=levoai/crapi-workshop-cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           

--- a/.github/workflows/build-and-release-crapi-workshop.yml
+++ b/.github/workflows/build-and-release-crapi-workshop.yml
@@ -31,7 +31,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./crAPI/services/workshop
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: levoai/crapi-workshop:pr-build
       - name: Build and push
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/workshop

--- a/.github/workflows/build-and-release-crapi-workshop.yml
+++ b/.github/workflows/build-and-release-crapi-workshop.yml
@@ -32,6 +32,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build image
+        if: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/workshop
@@ -40,7 +41,7 @@ jobs:
           cache-to: type=gha,mode=max
           tags: levoai/crapi-workshop:pr-build
       - name: Build and push
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         uses: docker/build-push-action@v5
         with:
           context: ./crAPI/services/workshop

--- a/.github/workflows/build-and-release-crapi-workshop.yml
+++ b/.github/workflows/build-and-release-crapi-workshop.yml
@@ -16,54 +16,28 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-workshop-image:
-    if: ${{ github.ref != 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
+  build-and-push-image:
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Build image
-        uses: aevea/action-kaniko@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-workshop
-          path: ./crAPI/services/workshop
-          tag: latest
-          cache: true
-          # Don't push the image, just build it to validate it.
-          extra_args: "--no-push --cache-repo levoai/crapi-workshop-cache"
-
-  push-latest-workshop-image:
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Latest image push
-        uses: aevea/action-kaniko@master
+      - name: Build and push
+        uses: docker/build-push-action@v5
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-workshop
-          path: ./crAPI/services/workshop
-          tag: latest
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-workshop-cache"
-
-  release-workshop-image:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Tagged image push
-        uses: aevea/action-kaniko@master
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          image: levoai/crapi-workshop
-          path: ./crAPI/services/workshop
-          strip_tag_prefix: v
-          cache: true
-          extra_args: "--cache-repo levoai/crapi-workshop-cache"
+          context: ./crAPI/services/workshop
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: levoai/crapi-workshop:latest
+          cache-from: type=registry,ref=levoai/crapi-workshop-cache
+          cache-to: type=registry,ref=levoai/crapi-workshop-cache,mode=max
+          

--- a/crAPI/deploy/k8s/base/community/deployment.yaml
+++ b/crAPI/deploy/k8s/base/community/deployment.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: crapi-community
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       initContainers:
         - name: wait-for-postgres
           image: groundnuty/k8s-wait-for:v2.0

--- a/crAPI/deploy/k8s/base/identity/deployment.yaml
+++ b/crAPI/deploy/k8s/base/identity/deployment.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: crapi-identity
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       initContainers:
         - name: wait-for-postgres
           image: groundnuty/k8s-wait-for:v2.0

--- a/crAPI/deploy/k8s/base/mailhog/deployment.yaml
+++ b/crAPI/deploy/k8s/base/mailhog/deployment.yaml
@@ -17,14 +17,12 @@ spec:
       annotations:
         sidecar.traceable.ai/inject: "false"
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       securityContext:
         runAsUser: 0
         runAsGroup: 0
       containers:
         - name: mailhog
-          image: mailhog/mailhog
+          image: jcalonso/mailhog
           imagePullPolicy: "IfNotPresent"
           livenessProbe:
             tcpSocket:

--- a/crAPI/deploy/k8s/base/web/deployment.yaml
+++ b/crAPI/deploy/k8s/base/web/deployment.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: crapi-web
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       containers:
       - name: crapi-web
         image: levoai/crapi-web:latest

--- a/crAPI/deploy/k8s/base/workshop/deployment.yaml
+++ b/crAPI/deploy/k8s/base/workshop/deployment.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         app: crapi-workshop
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
       initContainers:
         - name: wait-for-crapi-identity
           image: groundnuty/k8s-wait-for:v2.0

--- a/crAPI/deploy/k8s/gcp/mailhog/deployment.yaml
+++ b/crAPI/deploy/k8s/gcp/mailhog/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         runAsGroup: 0
       containers:
         - name: mailhog
-          image: mailhog/mailhog
+          image: jcalonso/mailhog
           imagePullPolicy: "IfNotPresent"
           livenessProbe:
             tcpSocket:

--- a/crAPI/deploy/k8s/gcp/mailhog/ingress.yaml
+++ b/crAPI/deploy/k8s/gcp/mailhog/ingress.yaml
@@ -13,4 +13,4 @@ spec:
     app: mailhog
   sessionAffinity: None
   type: LoadBalancer
-  loadBalancerIP: "35.232.101.208"
+  # loadBalancerIP: "35.232.101.208"

--- a/crAPI/deploy/k8s/gcp/web/ingress.yaml
+++ b/crAPI/deploy/k8s/gcp/web/ingress.yaml
@@ -15,4 +15,4 @@ spec:
   type: LoadBalancer
   selector:
     app: crapi-web
-  loadBalancerIP: "35.226.144.72"
+  # loadBalancerIP: "35.226.144.72"

--- a/crAPI/services/community/Dockerfile
+++ b/crAPI/services/community/Dockerfile
@@ -45,9 +45,9 @@ EXPOSE 8087
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
     
 RUN chmod +x /wait

--- a/crAPI/services/community/Dockerfile
+++ b/crAPI/services/community/Dockerfile
@@ -15,10 +15,12 @@
 
 # GoLang Build
 FROM golang:alpine AS builder
+ARG TARGETARCH
+ARG TARGETOS
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+    GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH
 WORKDIR /build
 COPY ./go.mod .
 COPY ./go.sum .
@@ -41,7 +43,13 @@ COPY --from=builder /dist/main /app/main
 RUN ls -al /app
 EXPOSE 8087
 
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+    else \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+    fi
+    
 RUN chmod +x /wait
 
 CMD /wait && /app/main

--- a/crAPI/services/community/Dockerfile
+++ b/crAPI/services/community/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=builder /dist/main /app/main
 RUN ls -al /app
 EXPOSE 8087
 
+RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \

--- a/crAPI/services/community/Dockerfile
+++ b/crAPI/services/community/Dockerfile
@@ -43,12 +43,11 @@ COPY --from=builder /dist/main /app/main
 RUN ls -al /app
 EXPOSE 8087
 
-RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
     
 RUN chmod +x /wait

--- a/crAPI/services/identity/Dockerfile
+++ b/crAPI/services/identity/Dockerfile
@@ -32,11 +32,11 @@ EXPOSE 8080
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
-    
+
 RUN chmod +x /wait
 
 CMD /wait && java -jar /app/user-microservices-1.0-SNAPSHOT.jar

--- a/crAPI/services/identity/Dockerfile
+++ b/crAPI/services/identity/Dockerfile
@@ -30,12 +30,11 @@ RUN mkdir /app
 COPY --from=javabuild /app/target/user-microservices-1.0-SNAPSHOT.jar /app/user-microservices-1.0-SNAPSHOT.jar
 EXPOSE 8080
 
-RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
 
 RUN chmod +x /wait

--- a/crAPI/services/identity/Dockerfile
+++ b/crAPI/services/identity/Dockerfile
@@ -30,7 +30,13 @@ RUN mkdir /app
 COPY --from=javabuild /app/target/user-microservices-1.0-SNAPSHOT.jar /app/user-microservices-1.0-SNAPSHOT.jar
 EXPOSE 8080
 
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+    else \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+    fi
+    
 RUN chmod +x /wait
 
 CMD /wait && java -jar /app/user-microservices-1.0-SNAPSHOT.jar

--- a/crAPI/services/identity/Dockerfile
+++ b/crAPI/services/identity/Dockerfile
@@ -30,6 +30,7 @@ RUN mkdir /app
 COPY --from=javabuild /app/target/user-microservices-1.0-SNAPSHOT.jar /app/user-microservices-1.0-SNAPSHOT.jar
 EXPOSE 8080
 
+RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \

--- a/crAPI/services/web/Dockerfile
+++ b/crAPI/services/web/Dockerfile
@@ -43,9 +43,9 @@ EXPOSE 443
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
     
 RUN chmod +x /wait

--- a/crAPI/services/web/Dockerfile
+++ b/crAPI/services/web/Dockerfile
@@ -28,7 +28,7 @@ RUN ls /app/build
 
 # Main Image
 FROM openresty/openresty:1.17.8.2-alpine
-RUN apk add gettext curl
+RUN apk add gettext curl 
 # React
 RUN rm /etc/nginx/conf.d/default.conf
 COPY --from=build /app/build /usr/share/nginx/html
@@ -41,12 +41,11 @@ RUN echo "daemon off;" >> /usr/local/openresty/nginx/conf/nginx.conf
 EXPOSE 80
 EXPOSE 443
 
-RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
     
 RUN chmod +x /wait

--- a/crAPI/services/web/Dockerfile
+++ b/crAPI/services/web/Dockerfile
@@ -41,8 +41,13 @@ RUN echo "daemon off;" >> /usr/local/openresty/nginx/conf/nginx.conf
 EXPOSE 80
 EXPOSE 443
 
-
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+    else \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+    fi
+    
 RUN chmod +x /wait
 
 CMD /wait && /etc/nginx/nginx-wrapper.sh

--- a/crAPI/services/web/Dockerfile
+++ b/crAPI/services/web/Dockerfile
@@ -41,6 +41,7 @@ RUN echo "daemon off;" >> /usr/local/openresty/nginx/conf/nginx.conf
 EXPOSE 80
 EXPOSE 443
 
+RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \

--- a/crAPI/services/workshop/Dockerfile
+++ b/crAPI/services/workshop/Dockerfile
@@ -39,9 +39,9 @@ FROM python:3.8-alpine3.15
 
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
     
 RUN chmod +x /wait

--- a/crAPI/services/workshop/Dockerfile
+++ b/crAPI/services/workshop/Dockerfile
@@ -37,6 +37,7 @@ RUN pip install wheel && pip wheel . --wheel-dir /app/wheels
 
 FROM python:3.8-alpine3.15
 
+RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \

--- a/crAPI/services/workshop/Dockerfile
+++ b/crAPI/services/workshop/Dockerfile
@@ -37,12 +37,11 @@ RUN pip install wheel && pip wheel . --wheel-dir /app/wheels
 
 FROM python:3.8-alpine3.15
 
-RUN apt-get update && apt-get install -y wget
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \
     else \
-        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
+        curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait; \
     fi
     
 RUN chmod +x /wait

--- a/crAPI/services/workshop/Dockerfile
+++ b/crAPI/services/workshop/Dockerfile
@@ -37,6 +37,7 @@ RUN pip install wheel && pip wheel . --wheel-dir /app/wheels
 
 FROM python:3.8-alpine3.15
 
+RUN apk add --update --no-cache curl
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
         curl -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64; \

--- a/crAPI/services/workshop/Dockerfile
+++ b/crAPI/services/workshop/Dockerfile
@@ -36,7 +36,14 @@ COPY ./ /app
 RUN pip install wheel && pip wheel . --wheel-dir /app/wheels
 
 FROM python:3.8-alpine3.15
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait_aarch64 \
+    else \
+        wget -o wait https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait \
+    fi
+    
 RUN chmod +x /wait
 COPY --from=build /app /app
 WORKDIR /app


### PR DESCRIPTION
Question:
Do we need to save the different caches from every build and use just the last ones?
![Screenshot 2024-02-20 at 13 34 46](https://github.com/levoai/demo-apps/assets/135211225/d78cd562-768c-4e9c-bdd4-97d5c0f96092)

I used the `latest` tag for the cache registries, so that we're storing it in the same image, and not hogging up storage space for cache that we might never use again.

Update: Using `type=gha` for the docker cache now. Abolishing buildling crapi-image-cache on dockerhub 