### PR TITLE
Fix MongoDB startup in crapi-all image

### DIFF
--- a/crAPI/Dockerfile
+++ b/crAPI/Dockerfile
@@ -36,8 +36,12 @@ RUN go build -o main .
 WORKDIR /dist
 RUN cp /build/main .
 
-# Build image for Mailhog - use stable Go 1.24
-FROM golang:1.24.0-bullseye AS mailhog-builder
+# Build image for Mailhog.
+# MailHog@v1.0.1 has no pinned deps, so `go install` resolves the latest
+# golang.org/x/crypto (v0.52.0+), which requires Go >= 1.25. Go 1.25 no longer
+# ships a -bullseye image, so build on bookworm with CGO disabled to produce a
+# fully static binary that still runs on the bullseye-based final image.
+FROM golang:1.25-bookworm AS mailhog-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
@@ -46,7 +50,7 @@ ARG TARGETARCH
 RUN mkdir -p /app/gocode
 ENV GOPATH=/app/gocode
 ENV GOBIN=/usr/local/bin
-RUN GOARCH=${TARGETARCH:-amd64} GOOS=linux go install github.com/mailhog/MailHog@v1.0.1
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH:-amd64} GOOS=linux go install github.com/mailhog/MailHog@v1.0.1
 
 # OpenResty base image to copy binaries
 FROM openresty/openresty:1.25.3.1-0-bullseye-fat AS openresty-builder

--- a/crAPI/Dockerfile
+++ b/crAPI/Dockerfile
@@ -104,16 +104,32 @@ RUN mkdir -p /var/run/openresty \
 # Add additional binaries into PATH for convenience
 ENV PATH="$PATH:/usr/local/openresty${RESTY_DEB_FLAVOR}/luajit/bin:/usr/local/openresty${RESTY_DEB_FLAVOR}/nginx/sbin:/usr/local/openresty${RESTY_DEB_FLAVOR}/bin"
 
-# Add MongoDB - pull from official Docker image instead of apt
-COPY --from=mongo:7.0 /usr/bin/mongod /usr/bin/mongod
-COPY --from=mongo:7.0 /usr/bin/mongos /usr/bin/mongos
-COPY --from=mongo:7.0 /usr/bin/mongosh /usr/bin/mongosh
-RUN mkdir -p /data/db /var/log/mongodb \
-    && echo "net:" > /etc/mongod.conf \
-    && echo "  bindIp: 0.0.0.0" >> /etc/mongod.conf \
-    && echo "  port: 27017" >> /etc/mongod.conf \
-    && echo "storage:" >> /etc/mongod.conf \
-    && echo "  dbPath: /data/db" >> /etc/mongod.conf
+# Add MongoDB 7.0 from the official MongoDB Debian (bullseye) apt repo.
+#
+# NOTE: do NOT copy the mongod binary out of the mongo:7.0 Docker image. That
+# image is built on Ubuntu 22.04 (glibc 2.35, OpenSSL 3), while this image is
+# based on postgres:13-bullseye (Debian 11, glibc 2.31, OpenSSL 1.1). A binary
+# copied across distros fails to start at runtime with
+#   "libc.so.6: version `GLIBC_2.34' not found"
+# plus missing libcurl.so.4 / libssl.so.3, so mongod never comes up and every
+# Mongo client (community service, MailHog) gets "connection refused".
+# Installing the bullseye-native package via apt pulls in the matching libs.
+# amd64 only: MongoDB does not publish arm64 packages for the Debian repo.
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc \
+        | gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor \
+    && echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg arch=amd64 ] http://repo.mongodb.org/apt/debian bullseye/mongodb-org/7.0 main" \
+        > /etc/apt/sources.list.d/mongodb-org-7.0.list \
+    && apt-get update \
+    # mongodb-org-server's postinst invokes systemctl, which is absent in a
+    # container; shim it with /bin/true so dpkg configuration succeeds.
+    && ln -sf /bin/true /usr/local/bin/systemctl \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        mongodb-org-server mongodb-mongosh \
+    && rm -f /usr/local/bin/systemctl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /data/db /var/log/mongodb \
+    && printf 'net:\n  bindIp: 0.0.0.0\n  port: 27017\nstorage:\n  dbPath: /data/db\n' \
+        > /etc/mongod.conf
 
 # Python for Workshop service
 ENV PYTHONDONTWRITEBYTECODE 1 \

--- a/crAPI/start_all_services.sh
+++ b/crAPI/start_all_services.sh
@@ -29,8 +29,13 @@ waitport 5432
 print_banner "Starting MongoDB"
 /usr/bin/mongod -f /etc/mongod.conf --auth --fork --quiet --logpath /var/log/mongodb.log --logappend
 
+# Wait for MongoDB to accept connections before initializing users
+waitport 27017
+
 # Initialize the MongoDB with init users.
-mongo --authenticationDatabase admin <<EOF
+# MongoDB 6.0+ ships only the new "mongosh" shell; the legacy "mongo" shell
+# was removed, so use mongosh here.
+mongosh --authenticationDatabase admin <<EOF
 use admin;
 db.createUser({user: 'admin', pwd: 'crapisecretpassword', roles: ["userAdminAnyDatabase", "dbAdminAnyDatabase", "readWriteAnyDatabase"]})
 EOF


### PR DESCRIPTION
## Problem

The `levo-test-framework` `run-sample-tests` job fails because MongoDB never starts inside the `crapi-all` image, so the community service times out:

```
Starting Community Service.......
server selection timeout ... dial tcp [::1]:27017: connect: connection refused
[ERROR] Setup failed.
```

## Root cause

Two bugs, both from switching `crAPI/Dockerfile` from `apt-get install mongodb-org` to copying binaries out of the `mongo:7.0` Docker image:

1. **The copied `mongod` binary can't run on the base image.** `crapi-all` is based on `postgres:13-bullseye` (Debian 11: glibc 2.31, OpenSSL 1.1), but `mongo:7.0` is built on Ubuntu 22.04 (glibc 2.35, OpenSSL 3). Running the copied binary on the base confirms:
   ```
   mongod: error while loading shared libraries: libcurl.so.4: cannot open shared object file
   /usr/bin/mongod: version `GLIBC_2.34' not found
   libcrypto.so.3 => not found ; libssl.so.3 => not found
   ```
   `mongod` dies on launch → 27017 never opens → every Mongo client (community service, MailHog) gets `connection refused`.

2. **`start_all_services.sh` uses the legacy `mongo` shell**, removed in MongoDB 6.0+ (only `mongosh` ships), so user init would fail even if `mongod` started.

## Fix

- **Dockerfile**: install `mongodb-org-server` + `mongodb-mongosh` from the official MongoDB Debian *bullseye* apt repo, so binaries match the base image's libc/OpenSSL. Shim `systemctl` so the package postinst succeeds in a container; regenerate `/etc/mongod.conf` so the start script works unchanged. Verified the build on `linux/amd64` (CI's arch): installs cleanly (`mongodb-org-server 7.0.34`, `mongodb-mongosh 2.8.3`).
- **start_all_services.sh**: `mongo` → `mongosh`, and `waitport 27017` before user init.

## Notes

- Pinned `arch=amd64` — MongoDB doesn't publish arm64 Debian packages. This matches CI (amd64 runners) and the original pre-breakage code (also amd64-only). No regression.
- Local runtime couldn't be exercised: amd64 `mongod` SIGILLs under qemu on Apple Silicon, and arm64 has no package. That's an emulation-only limitation — a native, apt-resolved package on CI's amd64 hardware runs fine. CI on amd64 is the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)