### PR TITLE
CU-86ba9pz96 ci: Skip all workflows on draft PRs

### DIFF
--- a/.github/workflows/build-and-release-crapi-community.yml
+++ b/.github/workflows/build-and-release-crapi-community.yml
@@ -2,6 +2,7 @@ name: Build crAPI community service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-community.yml'
       - 'crAPI/services/community/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-encryption-community.yml
+++ b/.github/workflows/build-and-release-crapi-encryption-community.yml
@@ -2,6 +2,7 @@ name: Build crAPIEncryption community service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-encryption-community.yml'
       - 'crAPIEncryption/services/community/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-encryption-identity.yml
+++ b/.github/workflows/build-and-release-crapi-encryption-identity.yml
@@ -2,6 +2,7 @@ name: Build crAPIEncryption identity service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-encryption-identity.yml'
       - 'crAPIEncryption/services/identity/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-encryption-web.yml
+++ b/.github/workflows/build-and-release-crapi-encryption-web.yml
@@ -2,6 +2,7 @@ name: Build crAPIEncryption web service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-encryption-web.yml'
       - 'crAPIEncryption/services/web/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-encryption-workshop.yml
+++ b/.github/workflows/build-and-release-crapi-encryption-workshop.yml
@@ -2,6 +2,7 @@ name: Build crAPIEncryption workshop service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-encryption-workshop.yml'
       - 'crAPIEncryption/services/workshop/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-identity.yml
+++ b/.github/workflows/build-and-release-crapi-identity.yml
@@ -2,6 +2,7 @@ name: Build crAPI identity service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-identity.yml'
       - 'crAPI/services/identity/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-web.yml
+++ b/.github/workflows/build-and-release-crapi-web.yml
@@ -2,6 +2,7 @@ name: Build crAPI web service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-web.yml'
       - 'crAPI/services/web/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-crapi-workshop.yml
+++ b/.github/workflows/build-and-release-crapi-workshop.yml
@@ -2,6 +2,7 @@ name: Build crAPI workshop service
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/build-and-release-crapi-workshop.yml'
       - 'crAPI/services/workshop/**'
@@ -17,6 +18,7 @@ on:
 
 jobs:
   build-and-push-image:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-release-malschema-images.yml
+++ b/.github/workflows/build-and-release-malschema-images.yml
@@ -2,6 +2,7 @@ name: Build and release malschema images
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/*-malschema-images.yml'
       - 'MalSchema/**'
@@ -18,7 +19,7 @@ on:
 jobs:
   build-malschema-image:
     name: Build malschema image
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +44,7 @@ jobs:
           extra_args: "--no-push"
 
   publish-malschema-image:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +69,7 @@ jobs:
 
   build-malschema-all-image:
     name: Build malschema-all image
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +96,7 @@ jobs:
 
   publish-malschema-all-image:
     name: Publish malschema-all latest image
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -122,7 +123,7 @@ jobs:
   release-malschema-image:
     name: Build and publish MalSchema container images to DockerHub
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-crapi-all-image.yml
+++ b/.github/workflows/publish-crapi-all-image.yml
@@ -2,6 +2,7 @@ name: Build and publish crapi-all image
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/*-crapi-all-image.yml'
       - 'crAPI/**'
@@ -13,7 +14,7 @@ on:
 jobs:
   build-docker-image:
     name: Build
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +57,7 @@ jobs:
 
   push-crapi-all-to-dockerhub:
     name: Publish
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-crapi-encryption-all-image.yml
+++ b/.github/workflows/publish-crapi-encryption-all-image.yml
@@ -2,6 +2,7 @@ name: Build and publish crapi-encryption-all image
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/*-crapi-encryption-all-image.yml'
       - 'crAPIEncryption/**'
@@ -13,7 +14,7 @@ on:
 jobs:
   build-docker-image:
     name: Build
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ github.ref != 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +57,7 @@ jobs:
 
   push-crapi-encryption-all-to-dockerhub:
     name: Publish
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Skip all CI workflows on draft PRs to save runner resources.
- Add `ready_for_review` to `pull_request` triggers so workflows fire when a draft is marked as ready.
- Add `if: github.event.pull_request.draft == false` (or the multi-trigger variant) on every job that could fire from a PR event.

## Workflows updated
- `build-and-release-crapi-community.yml`
- `build-and-release-crapi-encryption-community.yml`
- `build-and-release-crapi-encryption-identity.yml`
- `build-and-release-crapi-encryption-web.yml`
- `build-and-release-crapi-encryption-workshop.yml`
- `build-and-release-crapi-identity.yml`
- `build-and-release-crapi-web.yml`
- `build-and-release-crapi-workshop.yml`
- `build-and-release-malschema-images.yml`
- `publish-crapi-all-image.yml`
- `publish-crapi-encryption-all-image.yml`

## Test plan
- [ ] Open a draft PR — no workflows run.
- [ ] Push to the draft PR — still skipped.
- [ ] Mark "Ready for review" — workflows trigger.
- [ ] Non-PR triggers still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)